### PR TITLE
Task#2/criacao endpoint pesquisa herois

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <brainweb-interview-postgres-it.port>5432</brainweb-interview-postgres-it.port>
     </properties>
 
     <dependencies>
@@ -91,7 +92,6 @@
                     <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
                     <systemPropertyVariables>
-                        <!--suppress UnresolvedMavenProperty -->
                         <it-database.port>${brainweb-interview-postgres-it.port}</it-database.port>
                     </systemPropertyVariables>
                 </configuration>

--- a/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroController.java
+++ b/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroController.java
@@ -1,20 +1,26 @@
 package br.com.brainweb.interview.core.features.hero;
 
+import br.com.brainweb.interview.model.Hero;
 import br.com.brainweb.interview.model.request.CreateHeroRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.lang.String.format;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.ResponseEntity.created;
+import static org.springframework.http.ResponseEntity.notFound;
+import static org.springframework.http.ResponseEntity.ok;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,5 +34,17 @@ public class HeroController {
                                        @RequestBody CreateHeroRequest createHeroRequest) {
         final UUID id = heroService.create(createHeroRequest);
         return created(URI.create(format("/api/v1/heroes/%s", id))).build();
+    }
+
+    @GetMapping(path = "/{id}")
+    public ResponseEntity<Hero> getById(@PathVariable("id") String id) {
+
+        Optional<Hero> optionalHero = heroService.getById(UUID.fromString(id));
+
+        if (optionalHero.isPresent()) {
+            return ok(optionalHero.get());
+        }
+
+        return notFound().build();
     }
 }

--- a/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroController.java
+++ b/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroController.java
@@ -1,20 +1,26 @@
 package br.com.brainweb.interview.core.features.hero;
 
+import br.com.brainweb.interview.model.Hero;
 import br.com.brainweb.interview.model.request.CreateHeroRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.lang.String.format;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.ResponseEntity.created;
+import static org.springframework.http.ResponseEntity.notFound;
+import static org.springframework.http.ResponseEntity.ok;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,5 +34,17 @@ public class HeroController {
                                        @RequestBody CreateHeroRequest createHeroRequest) {
         final UUID id = heroService.create(createHeroRequest);
         return created(URI.create(format("/api/v1/heroes/%s", id))).build();
+    }
+
+    @GetMapping(path = "/{id}")
+    public ResponseEntity<Hero> getById(@PathVariable("id") String id) {
+
+        Optional<Hero> optionalHero = heroService.getById(id);
+
+        if (optionalHero.isPresent()) {
+            return ok(optionalHero.get());
+        }
+
+        return notFound().build();
     }
 }

--- a/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroRepository.java
+++ b/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroRepository.java
@@ -13,19 +13,35 @@ import java.util.UUID;
 public class HeroRepository {
 
     private static final String CREATE_HERO_QUERY = "INSERT INTO hero" +
-        " (name, race, power_stats_id)" +
-        " VALUES (:name, :race, :powerStatsId) RETURNING id";
+            " (name, race, power_stats_id)" +
+            " VALUES (:name, :race, :powerStatsId) RETURNING id";
+
+    private static final String FIND_HERO_BY_ID = "SELECT " +
+            "h.id, h.name, h.race, h.power_stats_id, h.enabled, h.created_at, h.updated_at " +
+            //"p.id, p.strength, p.agility, p.dexterity, p.intelligence, p.created_at, p.updated_at" +
+            "FROM hero h " +
+            "WHERE h.id =:id ";
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     UUID create(Hero hero) {
         final Map<String, Object> params = Map.of("name", hero.getName(),
-            "race", hero.getRace().name(),
-            "powerStatsId", hero.getPowerStatsId());
+                "race", hero.getRace().name(),
+                "powerStatsId", hero.getPowerStatsId());
 
         return namedParameterJdbcTemplate.queryForObject(
-            CREATE_HERO_QUERY,
-            params,
-            UUID.class);
+                CREATE_HERO_QUERY,
+                params,
+                UUID.class);
+    }
+
+    Hero findById(UUID heroId) {
+        final Map<String, Object> params = Map.of("id", heroId);
+
+        return this.namedParameterJdbcTemplate.queryForObject(
+                FIND_HERO_BY_ID,
+                params,
+                new HeroRowMapper()
+        );
     }
 }

--- a/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroRowMapper.java
+++ b/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroRowMapper.java
@@ -1,0 +1,23 @@
+package br.com.brainweb.interview.core.features.hero;
+
+import br.com.brainweb.interview.model.Hero;
+import br.com.brainweb.interview.model.enums.Race;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
+
+public class HeroRowMapper implements RowMapper<Hero> {
+
+    @Override
+    public Hero mapRow(ResultSet rs, int i) throws SQLException {
+        return Hero.builder()
+                .id(UUID.fromString(rs.getString("id")))
+                .name(rs.getString("name"))
+                .race(Race.valueOf(rs.getString("race")))
+                .powerStatsId(UUID.fromString(rs.getString("power_stats_id")))
+                .build();
+    }
+}

--- a/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroService.java
+++ b/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroService.java
@@ -5,6 +5,7 @@ import br.com.brainweb.interview.model.Hero;
 import br.com.brainweb.interview.model.PowerStats;
 import br.com.brainweb.interview.model.request.CreateHeroRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,8 +22,16 @@ public class HeroService {
 
     @Transactional
     public UUID create(CreateHeroRequest createHeroRequest) {
-
         UUID poweStatsId = this.powerStatsService.create(new PowerStats(createHeroRequest));
         return heroRepository.create(new Hero(createHeroRequest, poweStatsId));
+    }
+
+    public Optional<Hero> getById(UUID id) {
+        try {
+            Hero hero = this.heroRepository.findById(id);
+            return Optional.of(hero);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroService.java
+++ b/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroService.java
@@ -1,11 +1,14 @@
 package br.com.brainweb.interview.core.features.hero;
 
+import br.com.brainweb.interview.core.features.powerstats.PowerStatsService;
 import br.com.brainweb.interview.model.Hero;
+import br.com.brainweb.interview.model.PowerStats;
 import br.com.brainweb.interview.model.request.CreateHeroRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -14,8 +17,12 @@ public class HeroService {
 
     private final HeroRepository heroRepository;
 
+    private final PowerStatsService powerStatsService;
+
     @Transactional
     public UUID create(CreateHeroRequest createHeroRequest) {
-        return heroRepository.create(new Hero(createHeroRequest, null));
+
+        UUID poweStatsId = this.powerStatsService.create(new PowerStats(createHeroRequest));
+        return heroRepository.create(new Hero(createHeroRequest, poweStatsId));
     }
 }

--- a/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroService.java
+++ b/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroService.java
@@ -5,6 +5,7 @@ import br.com.brainweb.interview.model.Hero;
 import br.com.brainweb.interview.model.PowerStats;
 import br.com.brainweb.interview.model.request.CreateHeroRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,8 +22,16 @@ public class HeroService {
 
     @Transactional
     public UUID create(CreateHeroRequest createHeroRequest) {
-
         UUID poweStatsId = this.powerStatsService.create(new PowerStats(createHeroRequest));
         return heroRepository.create(new Hero(createHeroRequest, poweStatsId));
+    }
+
+    public Optional<Hero> getById(String id) {
+        try {
+            Hero hero = this.heroRepository.findById(UUID.fromString(id));
+            return Optional.of(hero);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/core/src/test/java/br/com/brainweb/interview/core/features/hero/HeroControllerTest.java
+++ b/core/src/test/java/br/com/brainweb/interview/core/features/hero/HeroControllerTest.java
@@ -1,10 +1,15 @@
 package br.com.brainweb.interview.core.features.hero;
 
+import br.com.brainweb.interview.model.Hero;
 import br.com.brainweb.interview.model.enums.Race;
 import br.com.brainweb.interview.model.request.CreateHeroRequest;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -12,10 +17,14 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -45,22 +54,70 @@ class HeroControllerTest {
 
         //when
         final ResultActions resultActions = mockMvc.perform(post("/api/v1/heroes")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(body));
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body));
 
         //then
         resultActions.andExpect(status().isCreated()).andExpect(header().exists("Location"));
         verify(heroService, times(1)).create(any());
     }
 
+    @Test
+    void shouldReturnTheHeroObjectInResponseBodyWhenRequestIdMatchWithAHeroIdInDatabase() throws Exception {
+
+        //given
+        String wantedHeroId = "1b9f3125-b59d-49c0-90df-2cf6be63e39f";
+        Mockito.when(heroService.getById(wantedHeroId)).thenReturn(Optional.of(this.createHero()));
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/heroes/" + wantedHeroId));
+
+        //then
+
+        resultActions.andExpect(status().is2xxSuccessful()).andExpect(mvcResult -> {
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+            mapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+            Assert.assertEquals(mvcResult.getResponse().getContentAsString(), mapper.writeValueAsString(createHero()));
+        });
+    }
+
+    @Test
+    void shouldReturnAnEmptyObjectInResponseBodyWhenRequestIdDoesNotMatchWithAnyHeroIdInDatabase() throws Exception {
+
+        //given
+        String inexistentHeroId = "93918f6f-861e-4cf9-b6f9-c2b78a55e7a3";
+        Mockito.when(heroService.getById(inexistentHeroId)).thenReturn(Optional.empty());
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/heroes/" + inexistentHeroId));
+
+        //then
+        resultActions.andExpect(status().is4xxClientError()).andExpect(mvcResult -> {
+            Assert.assertEquals(mvcResult.getResponse().getContentAsString(), "");
+        });
+    }
+
     private CreateHeroRequest createHeroRequest() {
         return CreateHeroRequest.builder()
-            .name("Batman")
-            .agility(5)
-            .dexterity(8)
-            .strength(6)
-            .intelligence(10)
-            .race(Race.HUMAN)
-            .build();
+                .name("Batman")
+                .agility(5)
+                .dexterity(8)
+                .strength(6)
+                .intelligence(10)
+                .race(Race.HUMAN)
+                .build();
+    }
+
+    private Hero createHero() {
+        return Hero.builder()
+                .id(UUID.fromString("1b9f3125-b59d-49c0-90df-2cf6be63e39f"))
+                .name("Martian Manhunter")
+                .powerStatsId(UUID.fromString("d1f59cb0-a999-41a9-b5bd-7f0d821a819f"))
+                .race(Race.ALIEN)
+                .createdAt(null)
+                .updatedAt(null)
+                .enabled(true)
+                .build();
     }
 }

--- a/core/src/test/java/br/com/brainweb/interview/core/features/hero/HeroServiceTest.java
+++ b/core/src/test/java/br/com/brainweb/interview/core/features/hero/HeroServiceTest.java
@@ -1,0 +1,61 @@
+package br.com.brainweb.interview.core.features.hero;
+
+import br.com.brainweb.interview.model.Hero;
+import br.com.brainweb.interview.model.enums.Race;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.dao.EmptyResultDataAccessException;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HeroServiceTest {
+
+    @InjectMocks
+    private HeroService service;
+
+    @Mock
+    private HeroRepository repository;
+
+    @Test
+    public void shouldBeReturnAnOptionalContainingTheWantedHeroIfItExists() {
+        //given
+        String wantedHeroId = "1b9f3125-b59d-49c0-90df-2cf6be63e39f";
+        Mockito.when(repository.findById(UUID.fromString(wantedHeroId))).thenReturn(this.createHero());
+
+        //when
+        Optional<Hero> wantedHero = this.service.getById(wantedHeroId);
+
+        //then
+        Assert.assertTrue(wantedHero.isPresent());
+        Assert.assertNotNull(wantedHero.get());
+    }
+
+    @Test
+    public void shouldBeReturnANullableOptionalIfWantedHeroDoesNotExists() {
+        //given
+        String inexistentHeroId = "93918f6f-861e-4cf9-b6f9-c2b78a55e7a3";
+        Mockito.when(repository.findById(UUID.fromString(inexistentHeroId))).thenThrow(new EmptyResultDataAccessException(0));
+
+        // when
+        Optional<Hero> wantedHero = this.service.getById(inexistentHeroId);
+
+        // then
+        Assert.assertFalse(wantedHero.isPresent());
+    }
+
+    private Hero createHero() {
+        return Hero.builder()
+                .id(UUID.fromString("1b9f3125-b59d-49c0-90df-2cf6be63e39f"))
+                .name("Martian Manhunter")
+                .powerStatsId(UUID.fromString("d1f59cb0-a999-41a9-b5bd-7f0d821a819f"))
+                .race(Race.ALIEN)
+                .build();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.12</version>
+                            <version>${lombok.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>${lombok.version}</version>
+                            <version>1.18.12</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>


### PR DESCRIPTION
* Criada estrutura para prover suporte para a pesquisa de heroi por id.
* Repositórios usando o método queryForObject (faz mais sentido que
usar o query, pois sempre será devolvido um único resultado, ou nenhum
caso o id pesquisado inexista), tratamento de erros colocada na
camada de serviço. Deveria a camada de acesso a dados trabalhar com
Optional, ou a implementação usada é realmente a mais correta (delegar
isso à camada de serviço)?
* Houve uma dúvida em relação à melhor forma de fazer o retorno do dado,
se usando o objeto de negócio (como foi entregue) ou se entregar um
objeto de visualização (DTO, ou VO - View Object), com as info do heroi
abertas (e não o objeto aninhadas através do id de power stats); por
fim, como é um projeto pequeno, segui nessa segunda abordagem e
entreguei em conjunto um endpoint para pesquisa de power stats,
conferinfo a responsabilidade de montar o objeto de visualização para o
cliente.